### PR TITLE
BUG: if origin isn't set in nrrd reader, set it to a reasonable default

### DIFF
--- a/ukf/NrrdData.cc
+++ b/ukf/NrrdData.cc
@@ -455,6 +455,19 @@ bool NrrdData::LoadSignal(const std::string& data_file, const bool normalizedDWI
   nrrdSpacingCalculate(this->_data_nrrd, 3, &spacing3, space_dir);
   _voxel = make_vec(spacing3, spacing2, spacing1);  // NOTE that the _voxel here is in reverse axis order!
 
+  // make sure something computable is in spacing.
+  for(unsigned int i = 0; i < this->_data_nrrd->dim; ++i)
+    {
+    if(!AIR_EXISTS(space_dir[i]))
+      {
+      space_dir[i] = 1.0;
+      }
+    if(!AIR_EXISTS(this->_data_nrrd->spaceOrigin[i]))
+      {
+      this->_data_nrrd->spaceOrigin[i] = -( (_data_nrrd->axis[i].size / 2) * space_dir[i]);
+      }
+    }
+
   // DEBUGING
   // std::cout << "Voxel: " << _voxel._[0] << " " << _voxel._[1] << " " << _voxel._[2] << std::endl;
 


### PR DESCRIPTION
All this patch does is detect if the origin and/or spacing have not been set when the teem library reads NRRD file file, and sets it to a reasonable default if it has not.

When I tested this patch based on the test case Hans gave me, it produced good fiber tract VTK files.
