### PR TITLE
ENH: since Eigen doesn't need compiling or installation, don't do it

### DIFF
--- a/SuperBuild/External_Eigen.cmake
+++ b/SuperBuild/External_Eigen.cmake
@@ -53,19 +53,23 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
 
   ### --- Project specific additions here
   set(${proj}_CMAKE_OPTIONS
-      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/${proj}-install
       -DBUILD_TESTING:BOOL=OFF
-      
     )
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY "${git_protocol}://github.com/BRAINSia/eigen.git")
   set(${proj}_GIT_TAG "master")
+  set(${proj}_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/ExternalSources/${proj})
   ExternalProject_Add(${proj}
     #URL https://bitbucket.org/eigen/eigen/get/3.2.0.tar.gz
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/ExternalSources/${proj}
+    SOURCE_DIR ${${proj}_SOURCE_DIR}
+    # just download the source and use it for the include files,
+    # nothing important to compile
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
     BINARY_DIR ${proj}-build
     LOG_CONFIGURE 0  # Wrap configure in script to ignore log output from dashboards
     LOG_BUILD     0  # Wrap build in script to to ignore log output from dashboards
@@ -79,8 +83,8 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     DEPENDS
       ${${proj}_DEPENDENCIES}
   )
-  set(${extProjName}_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
-  set(${extProjName}_INCLUDE_DIR ${CMAKE_BINARY_DIR}/${proj}-install/include/eigen3)
+  set(${extProjName}_DIR ${${proj}_SOURCE_DIR})
+  set(${extProjName}_INCLUDE_DIR ${${proj}_SOURCE_DIR})
 else()
   if(${USE_SYSTEM_${extProjName}})
     find_package(${extProjName} ${${extProjName}_REQUIRED_VERSION} REQUIRED)


### PR DESCRIPTION
I (and Hans) have noticed some build problems with Eigen on some platforms, during the configuration stage, when building standalone.

I could probably have finessed those build problems but since Eigen is a 'header-only' library that requires no compilation (or installation for that matter) I cut the Gordian knot -- I suppressed everything except unpacking the source, and sets the include path to the source directory.
