### PR TITLE
COMP: REVERT Increase template depth for gcc.

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -280,11 +280,6 @@ macro(check_compiler_platform_flags)
   endif()
 endmacro()#End the platform check function
 
-## Eigen requires building with deeper template depths than the default.
-CHECK_CXX_SOURCE_COMPILES(-ftemplate-depth-127 CXX_ALLOWS_TEMPLATE_DEPTH)
-if(DEFINED CXX_ALLOWS_TEMPLATE_DEPTH)
-  set(CXX_TEMPLATE_DEPTH_FLAG -ftemplate-depth-127)
-endif()
 #-----------------------------------------------------------------------------
 #Check the set of warning flags the compiler supports
 check_compiler_warning_flags(C_WARNING_FLAGS CXX_WARNING_FLAGS)
@@ -293,7 +288,7 @@ check_compiler_warning_flags(C_WARNING_FLAGS CXX_WARNING_FLAGS)
 # We do not set them in ITK_REQUIRED FLAGS because all project which
 # use ITK don't require these flags .
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_WARNING_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_WARNING_FLAGS} ${CXX_TEMPLATE_DEPTH_FLAG}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_WARNING_FLAGS}")
 
 #-----------------------------------------------------------------------------
 #Check the set of platform flags the compiler supports


### PR DESCRIPTION
This reverts commit e8ac38e971e4e6806204db10dd2a2720f79241b5.

The problem was that Slicer was explicitly restricting the template
depth to -ftemplate-depth-50 as was needed for the gcc3 compilers.

This was code copied from ITKv3 many years ago.
