### PR TITLE
COMP: change VTK build script to work with all CMake Generators

### DIFF
--- a/SuperBuild/External_VTK_build_step.cmake.in
+++ b/SuperBuild/External_VTK_build_step.cmake.in
@@ -8,7 +8,7 @@ if(UNIX)
   endif()
 
   execute_process(
-    COMMAND make
+    COMMAND ${CMAKE_COMMAND} --build .
     WORKING_DIRECTORY "@CMAKE_CURRENT_BINARY_DIR@/@proj@-build"
     )
 

--- a/fibertractdispersion/fiberbundle.cxx
+++ b/fibertractdispersion/fiberbundle.cxx
@@ -141,16 +141,28 @@ fiberbundle
   for(std::map<std::string,std::vector<float> >::const_iterator it = AllDecorators.begin();
       it != AllDecorators.end(); ++it)
     {
+#if 0
     vtkSmartPointer<vtkFloatArray> curAtt = vtkSmartPointer<vtkFloatArray>::New();
     curAtt->SetNumberOfComponents(1);
-    curAtt->Allocate(it->second.size());
     curAtt->SetName(it->first.c_str());
+    curAtt->Allocate(it->second.size());
     for(vtkIdType j = 0; j < static_cast<vtkIdType>(it->second.size()); ++j)
       {
       curAtt->InsertNextValue(it->second[j]);
       }
     int idx = pd->AddArray(curAtt);
     pd->SetActiveAttribute(idx,vtkDataSetAttributes::SCALARS);
+#else
+    vtkSmartPointer<vtkDoubleArray> curAtt = vtkSmartPointer<vtkDoubleArray>::New();
+    curAtt->SetNumberOfComponents(1);
+    curAtt->SetName(it->first.c_str());
+    for(unsigned int i = 0; i < it->second.size(); ++i)
+      {
+      double curVal = it->second[i];
+      curAtt->InsertNextTuple(&curVal);
+      }
+    pd->AddArray(curAtt);
+#endif
     }
   // TODO: do the tensors.
   for(std::map<std::string, stdMat_t>::const_iterator it = AllTensors.begin(); it != AllTensors.end(); ++it)

--- a/ukf/Testing/Cxx/CMakeLists.txt
+++ b/ukf/Testing/Cxx/CMakeLists.txt
@@ -40,7 +40,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     )
 set_property(TEST ${testname} PROPERTY LABELS ${CLP})
@@ -74,7 +73,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     --freeWater
     --recordFreeWater
@@ -109,7 +107,6 @@ add_test(NAME ${testname}
  --numThreads 1
  --minBranchingAngle 0.0
  --maxBranchingAngle 0.0
- --simpleTensorModel
  --recordNMSE
  --minFA 0.10
  --minGA 0.05
@@ -150,7 +147,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     --freeWater
     --recordFreeWater
@@ -187,7 +183,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     --freeWater
     --recordFreeWater
@@ -223,7 +218,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     --freeWater
     --recordFreeWater


### PR DESCRIPTION
BUG:  --simpleTensorModel flag went away

Replaced with --fullTensorModel, which defaults to false.

COMP: try to figure out VTK Output Data problems in Slicer

See https://www.icts.uiowa.edu/jira/browse/PREDICTIMG-3505 The
complaint is that Slicer is not liking the VTK files made
by fiberbundle.
