### PR TITLE
COMP: change VTK build script to work with all CMake Generators

### DIFF
--- a/SuperBuild/External_VTK_build_step.cmake.in
+++ b/SuperBuild/External_VTK_build_step.cmake.in
@@ -8,7 +8,7 @@ if(UNIX)
   endif()
 
   execute_process(
-    COMMAND make
+    COMMAND ${CMAKE_COMMAND} --build .
     WORKING_DIRECTORY "@CMAKE_CURRENT_BINARY_DIR@/@proj@-build"
     )
 

--- a/fibertractdispersion/computedispersion.cxx
+++ b/fibertractdispersion/computedispersion.cxx
@@ -98,12 +98,14 @@ void
 cell2mat(const MatrixVector &fibers /*in*/,MatrixType &tractMatrix /*out*/)
 {
   const unsigned int fibersSize(fibers.size());
-  tractMatrix.conservativeResize(fibers[0].rows(),fibers[0].cols() * fibersSize);
+  int rows = fibers[0].rows();
   for(unsigned int i = 0, offset = 0; i < fibersSize; ++i)
     {
     const MatrixType &curFiber = fibers[i];
+    int curCols = curFiber.cols();
+    tractMatrix.conservativeResize(rows,offset + curCols);
     tractMatrix.block(0,offset,curFiber.rows(),curFiber.cols()) = curFiber;
-    offset += curFiber.cols();;
+    offset += curCols;
     }
 }
 
@@ -653,11 +655,11 @@ computedispersion(fiberbundle &bundle, double scale,
       // take the median of the computed means
       MatrixType pointDDF = dispersionDistributionValues.block(0,i,numberOfSamplingDirections,1);
       std::vector<double> nonNegDDF;
-      for(unsigned int i = 0; i < pointDDF.rows(); ++i)
+      for(unsigned int k = 0; k < pointDDF.rows(); ++k)
         {
-        if(pointDDF(i,0) != -1)
+        if(pointDDF(k,0) != -1)
           {
-          nonNegDDF.push_back(pointDDF(i,0));
+          nonNegDDF.push_back(pointDDF(k,0));
           }
         }
       if(nonNegDDF.size() > 0)

--- a/fibertractdispersion/fiberbundle.cxx
+++ b/fibertractdispersion/fiberbundle.cxx
@@ -143,14 +143,13 @@ fiberbundle
     {
     vtkSmartPointer<vtkFloatArray> curAtt = vtkSmartPointer<vtkFloatArray>::New();
     curAtt->SetNumberOfComponents(1);
-    curAtt->Allocate(it->second.size());
     curAtt->SetName(it->first.c_str());
+    curAtt->Allocate(it->second.size());
     for(vtkIdType j = 0; j < static_cast<vtkIdType>(it->second.size()); ++j)
       {
       curAtt->InsertNextValue(it->second[j]);
       }
-    int idx = pd->AddArray(curAtt);
-    pd->SetActiveAttribute(idx,vtkDataSetAttributes::SCALARS);
+    pd->SetScalars(curAtt);
     }
   // TODO: do the tensors.
   for(std::map<std::string, stdMat_t>::const_iterator it = AllTensors.begin(); it != AllTensors.end(); ++it)
@@ -169,9 +168,7 @@ fiberbundle
           tmp[v] = (*it2)(i,j);
           }
         }
-      curAtt->InsertNextTuple(tmp);
-      int idx = pd->AddArray(curAtt);
-      pd->SetActiveAttribute(idx,vtkDataSetAttributes::TENSORS);
+      pd->SetTensors(curAtt);
       }
     }
 

--- a/ukf/Testing/Cxx/CMakeLists.txt
+++ b/ukf/Testing/Cxx/CMakeLists.txt
@@ -40,7 +40,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     )
 set_property(TEST ${testname} PROPERTY LABELS ${CLP})
@@ -74,7 +73,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     --freeWater
     --recordFreeWater
@@ -109,7 +107,6 @@ add_test(NAME ${testname}
  --numThreads 1
  --minBranchingAngle 0.0
  --maxBranchingAngle 0.0
- --simpleTensorModel
  --recordNMSE
  --minFA 0.10
  --minGA 0.05
@@ -150,7 +147,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     --freeWater
     --recordFreeWater
@@ -187,7 +183,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     --freeWater
     --recordFreeWater
@@ -223,7 +218,6 @@ add_test(NAME ${testname}
     --numThreads 1
     --minBranchingAngle 0.0
     --maxBranchingAngle 0.0
-    --simpleTensorModel
     --recordNMSE
     --freeWater
     --recordFreeWater


### PR DESCRIPTION
BUG:  --simpleTensorModel flag went away

BUG: Cell2Mat didn't handle input vector with variably sized matrices

Replaced with --fullTensorModel, which defaults to false.

COMP: use vtkDataSetAttributes::SetScalars/SetTensors to add data to vtkPolyData to write out

See https://www.icts.uiowa.edu/jira/browse/PREDICTIMG-3505 The
complaint is that Slicer is not liking the VTK files made
by fiberbundle.
