### PR TITLE
Diffusion propagator

### DIFF
--- a/ukf/CMakeLists.txt
+++ b/ukf/CMakeLists.txt
@@ -33,6 +33,7 @@ set(MODULE_SRCS
   filter_Simple2T.cc
   filter_Simple2T_FW.cc
   filter_Simple3T.cc
+  filter_Simple2BiExp_FW.cc
   )
 
 set(MODULE_TARGET_LIBRARIES

--- a/ukf/UKFTractography.cxx
+++ b/ukf/UKFTractography.cxx
@@ -243,11 +243,13 @@ int main(int argc, char **argv)
     if (noddi){
       if (numTensor == 1)
         setAndTell(l_Qm, 0.0025, "Qm");
-      else if (diffusionPropagator)
-        setAndTell(l_Qm, 0.0001, "Qm");
       else
         setAndTell(l_Qm, 0.001, "Qm");
-    } else if (numTensor == 1) {
+    } 
+    else if (diffusionPropagator) {
+        setAndTell(l_Qm, 0.0001, "Qm");
+    }
+    else if (numTensor == 1) {
         setAndTell(l_Qm, 0.005, "Qm");//l_Qm = 0.0015;
     } else {
       if (!simpleTensorModel) {
@@ -430,7 +432,7 @@ int main(int argc, char **argv)
     }
   else
     {
-    weightsOnTensors.norm(); // Normilize for all to add up to 1.
+    weightsOnTensors.norm(); // Normalize for all to add up to 1.
     }
 
 

--- a/ukf/UKFTractography.cxx
+++ b/ukf/UKFTractography.cxx
@@ -26,6 +26,7 @@ unsigned int countH=0;
 #include "filter_Simple2T.h"
 #include "filter_Simple2T_FW.h"
 #include "filter_Simple3T.h"
+#include "filter_Simple2BiExp_FW.h"
 #include "tractography.h"
 #include "UKFTractographyCLP.h"
 
@@ -59,6 +60,7 @@ int main(int argc, char **argv)
   ukfPrecisionType l_seedFALimit = seedFALimit;
   ukfPrecisionType l_Qm = Qm;
   ukfPrecisionType l_Ql = Ql;
+  ukfPrecisionType l_Qt = Qt;
   ukfPrecisionType l_Qw = Qw;
   ukfPrecisionType l_Qkappa = Qkappa;
   ukfPrecisionType l_Qvic = Qvic;
@@ -122,6 +124,60 @@ int main(int argc, char **argv)
         return 1 ;
     }
   }
+  if (diffusionPropagator) { 
+    if (noddi) {
+      std::cout<<"Noddi and Diffusion Propagator parameters are mutually exclusive. Use either one of the two"<<std::endl;
+      return 1;
+    } 
+    
+    if (recordFA || recordTrace) {
+      std::cout << "recordFA and recordTrace cannot be used with the diffusion propagator model\n";
+      return 1 ;
+    }
+     
+    if (!freeWater) {
+      std::cout<<"Since the Diffusion Propagator model is used, the free water parameter will be estimated"<<std::endl;
+      freeWater = true;
+    }
+    
+    if (!simpleTensorModel) {
+      std::cout<<"Since the Diffusion Propagator model is used, the simple tensor model will be used"<<std::endl;
+      simpleTensorModel = true;
+    }
+    
+    if (numTensor != 2) {
+      std::cout<<"Since the Diffusion Propagator model is used, the number of tensors is set to two (2)"<<std::endl;
+      numTensor = 2;
+    }    
+  
+  }
+  
+  if (recordRTOP && !diffusionPropagator) {
+    std::cout<<"recordRTOP cannot be used with any other models than the diffusionPropagator"<<std::endl;
+    return 1;
+  }
+  
+  if (l_Qt != 0.0 && !diffusionPropagator) {
+    std::cout<<"Qt parameter cannot be set with any other models than the diffusionPropagator model"<<std::endl;
+    return 1; 
+  }
+  
+  if (minRTOP != 0.0 && !diffusionPropagator) {
+    std::cout<<"minRTOP parameter cannot be set with any other models than the diffusionPropagator model"<<std::endl;
+    return 1; 
+  }
+  
+  if (maxNMSE != 0.0 && !diffusionPropagator) {
+    std::cout<<"maxNMSE parameter cannot be set with any other models than the diffusionPropagator model"<<std::endl;
+    return 1;   
+  }
+  
+  if (maxUKFIterations != 0 && !diffusionPropagator) {
+    std::cout<<"maxUKFIterations parameter cannot be set with any other models than the diffusionPropagator model"<<std::endl;
+    return 1;   
+  }
+  
+  
 //   if (l_stepLength <= 0){
 //     std::cout << "Invalid step length!" << std::endl ;
 //     return 1 ;
@@ -187,6 +243,8 @@ int main(int argc, char **argv)
     if (noddi){
       if (numTensor == 1)
         setAndTell(l_Qm, 0.0025, "Qm");
+      else if (diffusionPropagator)
+        setAndTell(l_Qm, 0.0001, "Qm");
       else
         setAndTell(l_Qm, 0.001, "Qm");
     } else if (numTensor == 1) {
@@ -211,7 +269,10 @@ int main(int argc, char **argv)
   }
   else {
     if (l_Ql == 0.0) {
-      if (numTensor == 1) {
+      if (diffusionPropagator) {
+        setAndTell(l_Ql, 150, "Ql");
+      }
+      else if (numTensor == 1) {
         setAndTell(l_Ql, 300.0, "Ql");//l_Ql = 25.0;
       } else if (numTensor == 2) {
         setAndTell(l_Ql, 50.0, "Ql");//was l_Ql = 100.0; for old Interp3Signal
@@ -222,10 +283,53 @@ int main(int argc, char **argv)
         tell(l_Ql, "Ql");
     }
   }
+ // In the diffusion propagator model, Ql is used for the fast diffusion eigenvalues, and Qt for the slow diffusion.
+  if (diffusionPropagator) {
+    if (l_Qt == 0.0) {
+      setAndTell(l_Qt, 50, "Qt");
+    }
+    else {
+      tell(l_Qt, "Qt");
+    }
+  }
+  
+  if (diffusionPropagator) {
+    if (minRTOP == 0.0) {
+      setAndTell(minRTOP, 60.0, "minRTOP");
+    }
+    else {
+      tell(minRTOP, "minRTOP");
+    }
+  }
+  
+  if (diffusionPropagator) {
+    if (maxNMSE == 0.0) {
+      setAndTell(maxNMSE, 0.15, "maxNMSE");
+    }
+    else {
+      tell(maxNMSE, "maxNMSE");
+    }
+  }
+  
+  if (diffusionPropagator) {
+    if (maxUKFIterations == -1.0) {
+      setAndTell(maxUKFIterations, 5, "maxUKFIterations");
+    }
+    else {
+    if (maxUKFIterations < 0.0) {
+        std::cout<<"Error: maxUKFIterations cannot be negative. Exiting"<<std::endl;
+        exit(1);
+    }
+      tell(maxUKFIterations, "maxUKFIterations");
+    }
+  }  
 
 
   if (l_Rs == 0.0) {
-    if (numTensor == 1) {
+    if (diffusionPropagator) {
+      setAndTell(l_Rs, 0.015, "Rs");
+    }
+    else if (numTensor == 1) {
       setAndTell(l_Rs, 0.01, "Rs");//l_Rs = 0.02;
     } else {
       if (!simpleTensorModel) {
@@ -238,8 +342,14 @@ int main(int argc, char **argv)
     tell(l_Rs, "Rs");
   }
 
-  if (l_stepLength == 0.0) {
-    if (numTensor == 1) {
+  if (l_stepLength == 0.3 && diffusionPropagator)  {
+    setAndTell(l_stepLength, 0.5, "stepLength");
+  }
+  else if (l_stepLength == 0.0) {
+    if (diffusionPropagator) {
+      setAndTell(l_stepLength, 0.5, "stepLength");
+    }
+    else if (numTensor == 1) {
       setAndTell(l_stepLength, 0.3, "stepLength");
     } else if (numTensor == 2) {
       setAndTell(l_stepLength, 0.3, "stepLength"); //was 0.2 for old Interp3Signal
@@ -274,7 +384,10 @@ int main(int argc, char **argv)
   else
     if (freeWater) {
       if (l_Qw == 0.0) {
-        if (numTensor == 1) {
+        if (diffusionPropagator) {
+          setAndTell(l_Qw, 0.002, "Qw");
+        }
+        else if (numTensor == 1) {
           setAndTell(l_Qw, 0.0025, "Qw"); // estimated in a paramsearch // 0.0025
         } else if (numTensor == 2) {
           setAndTell(l_Qw, 0.0015, "Qw"); // 0.0015
@@ -324,8 +437,13 @@ int main(int argc, char **argv)
   // Initialize the tractography object.
   FilterModel *filter_model = NULL; //Silence warnings.  This will cause segfault if it ever reaches this point.
   Tractography::model_type filter_model_type = Tractography::_1T;
-
-  if (noddi){
+  
+  if (diffusionPropagator) {
+    std::cout << "Using Diffusion Propagator model (2 simple tensors, free water, bi-exponential)" << std::endl;
+    filter_model = new Simple2T_BiExp_FW(l_Qm, l_Ql, l_Qw, l_Rs, weightsOnTensors, freeWater, D_ISO, l_Qt);
+    filter_model_type = Tractography::_2T_BiExp_FW;
+    
+  } else if (noddi){
     if (numTensor == 1){
       std::cout << "Using NODDI 1-Fiber model." << std::endl;
       filter_model = new NODDI1F(l_Qm, l_Qkappa, l_Qvic, l_Rs, weightsOnTensors, noddi);
@@ -398,6 +516,8 @@ int main(int argc, char **argv)
                                          numTensor, seedsPerVoxel,
                                          l_minBranchingAngle, l_maxBranchingAngle,
                                          !simpleTensorModel, freeWater, noddi,
+                                         diffusionPropagator, minRTOP, recordRTOP,
+                                         maxNMSE, maxUKFIterations,
 
                                          l_stepLength, l_recordLength, l_maxHalfFiberLength,
                                          labels,

--- a/ukf/UKFTractography.cxx
+++ b/ukf/UKFTractography.cxx
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
     return 1;   
   }
   
-  if (maxUKFIterations != 0 && !diffusionPropagator) {
+  if (maxUKFIterations != -1.0 && !diffusionPropagator) {
     std::cout<<"maxUKFIterations parameter cannot be set with any other models than the diffusionPropagator model"<<std::endl;
     return 1;   
   }

--- a/ukf/UKFTractography.xml
+++ b/ukf/UKFTractography.xml
@@ -354,9 +354,63 @@
 </parameters>
 
 <parameters advanced="true">
-  <label>Not Used: Debug/Develop Only </label>
-  <description> </description>
+  <label>Diffusion Propagator model </label>
+  <description> Use the Bi-exponential diffusion propagator model, with 2 tensors (simple model) and free water </description>
+  
+    <boolean>
+      <name>diffusionPropagator</name>
+      <longflag>diffusionPropagator</longflag>
+      <label>Diffusion Propagator model </label>
+      <description>Use the Bi-exponential diffusion propagator model, with 2 tensors (simple model) and free water </description>
+      <default>false</default>
+    </boolean>
+    
+    <boolean>
+      <name>recordRTOP</name>
+      <longflag>recordRTOP</longflag>
+      <label>Record the return to origin probability </label>
+      <description>Record the return to origin probability when using the diffusion propagator model </description>
+      <default>false</default>
+    </boolean>
+    
+    <double>
+      <name>minRTOP</name>
+      <longflag>minRTOP</longflag>
+      <label>Stopping criteria: RTOP values computed from the signal below this minimum imply the termination of the fiber</label>
+      <description>Stopping criteria: RTOP values computed from the signal below this minimum implied the termination of the fiber. Default: 60.0</description>
+      <default>0.0</default>
+    </double>
+    
+    <double>
+      <name>Qt</name>
+      <longflag>Qt</longflag>
+      <label>UKF Parameter (Advanced): Rate of change of eigenvalues for the slow diffusion (diffusion propagator model)</label>
+      <description>UKF data fitting parameter for tensor model: Process noise for slow diffusion eigenvalues.</description>
+      <default>0.0</default>
+    </double>
+    
+    <double>
+      <name>maxNMSE</name>
+      <longflag>maxNMSE</longflag>
+      <label>Stopping criteria: maximum NMSE allowed when seeding and tracing fibers, in the case of the diffusion propagator model</label>
+      <description>Stopping criteria: maximum NMSE allowed when seeding and tracing fibers, in the case of the diffusion propagator model (default 0.2)</description>
+      <default>0.0</default>
+    </double>
+    
+    <double>
+      <name>maxUKFIterations</name>
+      <longflag>maxUKFIterations</longflag>
+      <label>Maximum number of iterations of the Kalman filter at a given position when following a fiber</label>
+      <description>Maximum number of iterations of the Kalman filter at a given position when following a fiber (default is 5)</description>
+      <default>-1.0</default>
+    </double>    
+      
+</parameters>
 
+<parameters advanced="true">
+  <label>Not Used: Debug/Develop Only </label>
+  <description> </description>  
+  
     <double>
       <name>sigmaSignal</name>
       <longflag>sigmaSignal</longflag>

--- a/ukf/filter_Simple2BiExp_FW.cc
+++ b/ukf/filter_Simple2BiExp_FW.cc
@@ -1,0 +1,204 @@
+#include "filter_Simple2BiExp_FW.h"
+
+////////// 2T Bi-Exponential SIMPLE MODEL ///
+// Functions for 2-tensor bi-exponential simple model.
+void Simple2T_BiExp_FW::F(ukfMatrixType& X) const
+{
+
+
+  assert(_signal_dim > 0);
+  assert(X.rows() == static_cast<unsigned int>(_state_dim) &&
+         (X.cols() == static_cast<unsigned int>(2 * _state_dim + 1) ||
+          X.cols() == 1));
+         
+         
+  for( unsigned int i = 0; i < X.cols(); ++i )
+    {
+    // Normalize the direction vectors.
+    
+    // Tensor 1
+    ukfPrecisionType norm_inv = ukfZero; // 1e-16;
+    norm_inv += X(0, i) * X(0, i);
+    norm_inv += X(1, i) * X(1, i);
+    norm_inv += X(2, i) * X(2, i);
+
+    norm_inv = ukfOne / sqrt(norm_inv);
+    X(0, i) *= norm_inv;
+    X(1, i) *= norm_inv;
+    X(2, i) *= norm_inv;
+
+    // Tensor 2
+    norm_inv = ukfZero; // 1e-16;
+    norm_inv += X(7, i) * X(7, i);
+    norm_inv += X(8, i) * X(8, i);
+    norm_inv += X(9, i) * X(9, i);
+
+    norm_inv = ukfOne / sqrt(norm_inv);
+    X(7, i) *= norm_inv;
+    X(8, i) *= norm_inv;
+    X(9, i) *= norm_inv;
+
+    // Check that the eigenvalues are greater or equal to the minimum value
+    // and less or equal to the maximum value
+    // Tensor 1
+    X(3, i) = std::max(X(3, i), _lambda_min_fast_diffusion);
+    X(4, i) = std::max(X(4, i), _lambda_min_fast_diffusion);
+    X(5, i) = std::max(X(5, i), _lambda_min_slow_diffusion);
+    X(6, i) = std::max(X(6, i), _lambda_min_slow_diffusion);
+    
+    X(3, i) = std::min(X(3, i), _lambda_max_diffusion);
+    X(4, i) = std::min(X(4, i), _lambda_max_diffusion); 
+    X(5, i) = std::min(X(5, i), _lambda_max_diffusion);
+    X(6, i) = std::min(X(6, i), _lambda_max_diffusion);
+    
+    // Tensor 2
+    X(10, i) = std::max(X(10, i), _lambda_min_fast_diffusion);
+    X(11, i) = std::max(X(11, i), _lambda_min_fast_diffusion);
+    X(12, i) = std::max(X(12, i), _lambda_min_slow_diffusion);
+    X(13, i) = std::max(X(13, i), _lambda_min_slow_diffusion);
+    
+    X(10, i) = std::min(X(10, i), _lambda_max_diffusion);
+    X(11, i) = std::min(X(11, i), _lambda_max_diffusion); 
+    X(12, i) = std::min(X(12, i), _lambda_max_diffusion);
+    X(13, i) = std::min(X(13, i), _lambda_max_diffusion);
+
+    // Free water
+    X(14, i) = CheckZero(X(14, i) );
+    }
+}
+
+void Simple2T_BiExp_FW::H(const   ukfMatrixType& X,
+                    ukfMatrixType& Y) const
+{
+  assert(_signal_dim > 0);
+  assert(X.rows() == static_cast<unsigned int>(_state_dim) &&
+         (X.cols() == static_cast<unsigned int>(2 * _state_dim + 1) ||
+          X.cols() == 1) );
+  assert(Y.rows() == static_cast<unsigned int>(_signal_dim) &&
+         (Y.cols() == static_cast<unsigned int>(2 * _state_dim + 1) ||
+          Y.cols() == 1) );
+  assert(_signal_data);
+
+  const stdVec_t&   gradients = _signal_data->gradients();
+  const ukfVectorType & b       = _signal_data->GetBValues();
+  for( unsigned int i = 0; i < X.cols(); ++i )
+    {
+    // Normalize directions.
+    vec3_t m1;
+    initNormalized(m1,X(0, i), X(1, i), X(2, i) );
+    vec3_t m2;
+    initNormalized(m2,X(7, i), X(8, i), X(9, i) );
+
+    diagmat3_t lambdas11, lambdas12, lambdas21, lambdas22;
+    
+    ukfPrecisionType l11 = std::max(X(3, i), _lambda_min_fast_diffusion);
+    ukfPrecisionType l12 = std::max(X(4, i), _lambda_min_fast_diffusion);
+    ukfPrecisionType l13 = std::max(X(5, i), _lambda_min_slow_diffusion);
+    ukfPrecisionType l14 = std::max(X(6, i), _lambda_min_slow_diffusion);
+    
+    l11 = std::min(l11, _lambda_max_diffusion);
+    l12 = std::min(l12, _lambda_max_diffusion);
+    l13 = std::min(l13, _lambda_max_diffusion);
+    l14 = std::min(l14, _lambda_max_diffusion);
+
+    ukfPrecisionType l21 = std::max(X(10, i), _lambda_min_fast_diffusion);
+    ukfPrecisionType l22 = std::max(X(11, i), _lambda_min_fast_diffusion);
+    ukfPrecisionType l23 = std::max(X(12, i), _lambda_min_slow_diffusion);
+    ukfPrecisionType l24 = std::max(X(13, i), _lambda_min_slow_diffusion);
+    
+    l21 = std::min(l21, _lambda_max_diffusion);
+    l22 = std::min(l22, _lambda_max_diffusion);
+    l23 = std::min(l23, _lambda_max_diffusion);
+    l24 = std::min(l24, _lambda_max_diffusion);
+
+    // Flip if necessary.
+    if( m1[0] < 0 )
+      {
+      m1 = -m1;
+      }
+    if( m2[0] < 0 )
+      {
+      m2 = -m2;
+      }
+
+    // Get free water weight from state
+    const ukfPrecisionType w = CheckZero(X(14, i) );
+
+    
+    lambdas11.diagonal()[0] = l11;
+    lambdas11.diagonal()[1] = l12;
+    lambdas11.diagonal()[2] = l12;
+  
+    lambdas12.diagonal()[0] = l13;
+    lambdas12.diagonal()[1] = l14;
+    lambdas12.diagonal()[2] = l14;
+    
+    lambdas21.diagonal()[0] = l21;
+    lambdas21.diagonal()[1] = l22;
+    lambdas21.diagonal()[2] = l22;
+   
+    lambdas22.diagonal()[0] = l23;
+    lambdas22.diagonal()[1] = l24;
+    lambdas22.diagonal()[2] = l24;
+    
+    // Calculate diffusion matrix.
+    const mat33_t &D1 = diffusion(m1, lambdas11);
+    const mat33_t &D1t = diffusion(m1, lambdas12);
+    const mat33_t &D2 = diffusion(m2, lambdas21);
+    const mat33_t &D2t = diffusion(m2, lambdas22);
+    
+    // Reconstruct signal.
+    for( int j = 0; j < _signal_dim; ++j )
+      {
+      // u = gradient direction considered
+      const vec3_t& u = gradients[j];
+      
+      Y(j,i) = 
+            w*( 
+                weights_on_tensors_[0] * ( _w_fast_diffusion * std::exp(-b[j]* u.dot(D1 * u)) + (1-_w_fast_diffusion) * std::exp( -b[j]* u.dot(D1t * u)) )
+                + weights_on_tensors_[1] * ( _w_fast_diffusion * std::exp(-b[j]* u.dot(D2 * u)) + (1-_w_fast_diffusion) * std::exp( -b[j]* u.dot(D2t * u)) )
+              )
+        + (1 - w) * std::exp( -b[j] * u.dot(m_D_iso * u) );
+      }
+    }
+
+}
+
+void Simple2T_BiExp_FW::State2Tensor2T(const State& x, const vec3_t& old_m, vec3_t& m1, vec3_t& l11, vec3_t& m2, vec3_t& l21)
+{
+  // Orientations;
+  initNormalized(m1, x[0], x[1], x[2]);
+  initNormalized(m2, x[7], x[8], x[9]);
+
+  // Tensor 1
+    // Lambda fast diffusion
+  l11[0] = std::max(x(3), _lambda_min_fast_diffusion);
+  l11[1] = std::max(x(4), _lambda_min_fast_diffusion);
+  l11[2] = l11[1];
+    // Lamda slow diffusion
+  /*l12[0] = std::max(x(5), _lambda_min_slow_diffusion);
+  l12[1] = std::max(x(6), _lambda_min_slow_diffusion);
+  l12[2] = l12[1];*/
+
+  // Tensor 2
+    // Lambda fast diffusion
+  l21[0] = std::max(x(10), _lambda_min_fast_diffusion);
+  l21[1] = std::max(x(11), _lambda_min_fast_diffusion);
+  l21[2] = l21[1];
+    // Lamda slow diffusion
+  /*l22[0] = std::max(x(12), _lambda_min_slow_diffusion);
+  l22[1] = std::max(x(13), _lambda_min_slow_diffusion);
+  l22[2] = l22[1];*/
+
+
+  // Flip orientations if necessary. (For m1 it should not happen, maybe for
+  // m2.)
+  if( m1[0] * old_m[0] + m1[1] * old_m[1] + m1[2] * old_m[2] < 0 )
+    {
+    m1 = -m1;
+    }
+  if( m2[0] * old_m[0] + m2[1] * old_m[1] + m2[2] * old_m[2] < 0 )
+    {
+    m2 = -m2;
+    }
+}

--- a/ukf/filter_Simple2BiExp_FW.h
+++ b/ukf/filter_Simple2BiExp_FW.h
@@ -1,0 +1,123 @@
+#ifndef SIMPLE2BIEXP_FW_H__
+#define SIMPLE2BIEXP_FW_H__
+#include "filter_model.h"
+
+
+
+/**
+ * \struct Simple2T_BiExp_FW
+ * \brief Simple 2-Tensor model with free water
+ *
+ * Model describing 2-tensor tractography with the simplified tensor representation (two minor eigenvalues are equal)
+ * and free water estimation
+*/
+class Simple2T_BiExp_FW : public FilterModel
+  {
+public:
+  Simple2T_BiExp_FW(ukfPrecisionType qs, ukfPrecisionType ql, ukfPrecisionType qw, ukfPrecisionType rs, const ukfVectorType& weights_on_tensors,
+              bool constrained, const ukfPrecisionType diff_fw, ukfPrecisionType qt)
+    : FilterModel(15, rs, weights_on_tensors, constrained), _lambda_min_fast_diffusion(1.0), _lambda_min_slow_diffusion(0.1), _lambda_max_diffusion(3000), _w_fast_diffusion(0.7), m_D_iso(SetIdentityScaled(diff_fw))
+  {
+
+    // 15 = size(X, 'column')
+    // X = [x10, x11, x12, l11, l12, l13, l14, x20, x21, x22, l21, l22, l23, l24, w]' 
+    //     [0  , 1  , 2  , 3  , 4  , 5  , 6  , 7  , 8  , 9  , 10 , 11 , 12 , 13 , 14]
+    // There are two tensors in this model, and we have a simple bi-exponential model, which means 2 lambdas per exponential (simple model), and 2 exponentials per tensor (bi-exponential)
+    // 1-w is the free water weight
+
+
+    // Q is the injected process noise bias. It is a diagonal matrix. It is used in the state transfer function.
+
+    _Q(0, 0) = _Q(1, 1) = _Q(2, 2) = _Q(7, 7) = _Q(8, 8) = _Q(9, 9) = qs;                                   // noise for the main direction
+    _Q(3, 3) = _Q(4, 4) =  _Q(10, 10) = _Q(11, 11) = ql;                                                    // noise for the lambdas (fast diffusion)
+    _Q(5, 5) = _Q(6, 6) =  _Q(12, 12) = _Q(13, 13) = qt;                                                    // noise for the lambdas (slow diffusion)
+    _Q(14, 14) = qw;                                                                                        // noise for the free water weight
+
+    // D is the constraint matrix. 
+    // The 1st dim of D is used to select which component of x we want to constraint, the 2nd is for the inequality (*-1 -> reverse the inequality)
+    // d is the contraint value
+    // D'*x >= -d
+    
+    // 18 constraints for the 15 dimensions of the state
+    _D.resize(15, 18);
+    _D.setConstant(ukfZero);
+
+    _d.resize(18);
+
+    // Setting the constraints according to D'*x >= -d
+    
+    // Free water
+    _D(14, 0) = -1;
+    _d(0) = 1;  // w <= 1
+    _D(14, 1) = 1;
+    _d(1) = 0;  // w >= 0
+
+    
+    // Tensor 1 (minimal values)
+    _D(3, 2)  = 1;
+    _d(2) = _lambda_min_fast_diffusion;  // l11 >= min
+    _D(4, 3)  = 1;
+    _d(3) = _lambda_min_fast_diffusion;  // l12 >= min
+    _D(5, 4)  = 1;
+    _d(4) = _lambda_min_slow_diffusion;  // l13 >= min
+    _D(6, 5)  = 1;
+    _d(5) = _lambda_min_slow_diffusion;  // l14 >= min
+    
+    
+    // Tensor 2 (minimal values)
+    _D(10, 6)  = 1;
+    _d(6) = _lambda_min_fast_diffusion;  // l21 >= min
+    _D(11, 7)  = 1;
+    _d(7) = _lambda_min_fast_diffusion;  // l22 >= min
+    _D(12, 8)  = 1;
+    _d(8) = _lambda_min_slow_diffusion;  // l23 >= min
+    _D(13, 9)  = 1;
+    _d(9) = _lambda_min_slow_diffusion;  // l21 >= min
+    
+    // Tensor 1 (maximal values)
+    _D(3, 10) = -1;                      // l11 <= max
+    _d(10) = _lambda_max_diffusion;
+    _D(4, 11) = -1;                      // l12 <= max
+    _d(11) = _lambda_max_diffusion;
+    _D(5, 12) = -1;                      // l13 <= max
+    _d(12) = _lambda_max_diffusion;
+    _D(6, 13) = -1;                      // l14 <= max
+    _d(13) = _lambda_max_diffusion;
+    
+    // Tensor 2 (maximal values)
+    _D(10, 14) = -1;                      // l21 <= max
+    _d(14) = _lambda_max_diffusion;
+    _D(11, 15) = -1;                      // l22 <= max
+    _d(15) = _lambda_max_diffusion;
+    _D(12, 16) = -1;                      // l23 <= max
+    _d(16) = _lambda_max_diffusion;
+    _D(13, 17) = -1;                      // l24 <= max
+    _d(17) = _lambda_max_diffusion;
+    
+
+  }
+
+  virtual ~Simple2T_BiExp_FW()
+  {
+  }
+
+  virtual void F(ukfMatrixType& X) const;
+
+  virtual void H(const  ukfMatrixType& X, ukfMatrixType& Y) const;
+
+  virtual void State2Tensor2T(const State& x, const vec3_t& old_m, vec3_t& m1, vec3_t& l11, vec3_t& m2, vec3_t& l21);
+
+  /** The minimum/maximum value of the eigenvalues. Clamped in each step */
+  const ukfPrecisionType _lambda_min_fast_diffusion;
+  const ukfPrecisionType _lambda_min_slow_diffusion;
+  const ukfPrecisionType _lambda_max_diffusion;
+  
+  /** The weight fraction of the fast diffusion component */
+  const ukfPrecisionType _w_fast_diffusion;
+
+  /** apparent diffusion coefficient of free water */
+  mat33_t m_D_iso;
+  };
+
+
+#endif  // SIMPLE2BIEXP_FW_H__

--- a/ukf/vtk_writer.cc
+++ b/ukf/vtk_writer.cc
@@ -98,6 +98,19 @@ VtkWriter::VtkWriter(const ISignalData *signal_data, Tractography::model_type fi
     _num_tensors = 3;
     _tensor_space = 6;
     }
+  else if( filter_model_type == Tractography::_2T_BiExp_FW )
+    {
+    _full = false;
+    _p_m1 = 0;
+    _p_m2 = 1;
+    _p_m3 = 2;
+    _p_l1 = 3;
+    _p_l2 = 4;
+    _p_l3 = 4;
+    _num_tensors = 2;
+    _tensor_space = 7;
+    
+    }
 
   // this also upon initialization of writer, its the same for all
   ukfMatrixType i2r = _signal_data->i2r();
@@ -263,7 +276,8 @@ Write(const std::string& file_name,
       const std::vector<UKFFiber>& fibers,
       bool write_state,
       bool store_glyphs,
-      bool if_noddi)
+      bool if_noddi,
+      bool diffusionPropagator)
 {
   if( fibers.size() == 0 )
     {
@@ -333,6 +347,8 @@ Write(const std::string& file_name,
     fa->Allocate(num_points);
     if(if_noddi)
       fa->SetName("Vic1");
+    else if (diffusionPropagator) 
+      fa->SetName("RTOP1");
     else
       fa->SetName("FA1");
     for( int i = 0; i < num_fibers; ++i )
@@ -353,6 +369,8 @@ Write(const std::string& file_name,
     vtkSmartPointer<vtkFloatArray> fa2 = vtkSmartPointer<vtkFloatArray>::New();
     if(if_noddi)
       fa2->SetName("Vic2");
+    else if (diffusionPropagator) 
+      fa2->SetName("RTOP2");
     else
       fa2->SetName("FA2");
     fa2->SetNumberOfComponents(1);
@@ -377,6 +395,8 @@ Write(const std::string& file_name,
     trace->Allocate(num_points);
     if(if_noddi)
       trace->SetName("OrientationDispersionIndex1");
+    else if (diffusionPropagator) 
+      trace->SetName("RTOP_model");
     else
       trace->SetName("trace1");
     for( int i = 0; i < num_fibers; ++i )
@@ -399,6 +419,8 @@ Write(const std::string& file_name,
     trace2->Allocate(num_points);
     if(if_noddi)
       trace2->SetName("OrientationDispersionIndex2");
+    else if (diffusionPropagator) 
+      trace2->SetName("RTOP_signal");
     else
       trace2->SetName("trace2");
     for( int i = 0; i < num_fibers; ++i )

--- a/ukf/vtk_writer.h
+++ b/ukf/vtk_writer.h
@@ -49,7 +49,7 @@ public:
   int Write(const std::string& file_name,
             const std::string & tractsWithSecondTensor,
             const std::vector<UKFFiber>& fibers,
-             bool write_state, bool store_glyphs, bool if_noddi);
+            bool write_state, bool store_glyphs, bool if_noddi, bool diffusionPropagator);
 
   /** Write the glyphs (i.e. main tensor directions) to  a file named glyphs_{tracts}.
    * \return EXIT_FAILURE or EXIT_SUCCESS


### PR DESCRIPTION
Diffusion Propagator model added

In this commit, the Diffusion Propagator model is added. It is a multi-tensor bi-exponential model, with free water estimation. The following changes were made:

- 5 flags have been added to the command line parser (--diffusionPropagator, --minRTOP, --maxNMSE, --maxUKFIterations and --recordRTOP) (UKFTractography.xml, UKFTractography.cxx)

- The model is implemented in filter_Simple2BiExp_FW.cc / filter_Simple2BiExp_FW.h

- filter_Simple2BiExp_FW.cc has been added to the CMakeLists.txt

- The VTK writer has been updated to take into account the recorded measures, which are the return-to-origin probabilites (RTOP), instead of FA and TRACE.

- UnpackTensor has been modified so that, when estimating the single tensor in the case of the diffusionPropagator model, only the gradients with a b-value between 800 and 1500 s/mm² are taken into account.

- When estimating the initial seed state, the LBFGSB optimizer from ITK is used for the non-linear least square fitting. It is also possible to iterate the UKF at the starting point to estimate the initial seed state, simply by uncommenting the call to the function InitLoopUKF, and by setting the desired number of iterations. However we found that the nl-LSQ fitting was giving better results.

- The Step2T function has been modified to allow multiple iterations of the UKF, when using the diffusionPropagator model.

- With this model, when following a fiber, negative free water will simply causes the fiber to stop instead of making the program exit.