### PR TITLE
ENH: rename input parameters to match current code

### DIFF
--- a/ukf/Testing/CMakeLists.txt
+++ b/ukf/Testing/CMakeLists.txt
@@ -120,8 +120,8 @@ add_test(NAME ${testname}
  --minBranchingAngle 0.0
  --maxBranchingAngle 0.0
  --recordNMSE
- --minFA 0.10
- --minGA 0.05
+ --stoppingFA 0.10
+ --stoppingThreshold 0.05
  --Qm 0.001
  --Ql 10
  --Rs 0.015
@@ -162,8 +162,8 @@ add_test(NAME ${testname}
   --recordNMSE
   --freeWater
   --recordFreeWater
-  --minFA 0.1
-  --minGA 0.05
+  --stoppingFA 0.1
+  --stoppingThreshold 0.05
   --Qm 0.01
   --Ql 10
   --Rs 0.015
@@ -198,8 +198,8 @@ add_test(NAME ${testname}
   --recordNMSE
   --freeWater
   --recordFreeWater
-  --minFA 0.1
-  --minGA 0.05
+  --stoppingFA 0.1
+  --stoppingThreshold 0.05
   --Qm 0.01
   --Ql 10
   --Rs 0.015
@@ -233,8 +233,8 @@ add_test(NAME ${testname}
   --recordNMSE
   --freeWater
   --recordFreeWater
-  --minFA 0.1
-  --minGA 0.05
+  --stoppingFA 0.1
+  --stoppingThreshold 0.05
   --Qm 0.01
   --Ql 10
   --Rs 0.015

--- a/ukf/Testing/generate_ground_truth.sh
+++ b/ukf/Testing/generate_ground_truth.sh
@@ -29,13 +29,13 @@ eval $my_command
 diff_im_path='Data/Input/two_tensor.nhdr'
 output_path='Data/Baseline/2T_fiber.vtk'
 my_command="$ukf_path --dwiFile $diff_im_path --maskFile $mask_path --tracts $output_path --seedsFile $seeds_path 
---seedsPerVoxel 1  --numTensor 2  --numThreads 1 --minBranchingAngle 0.0 --maxBranchingAngle 0.0 --minFA 0.10 --minGA 0.05 --Qm 0.001 --Ql 10 --Rs 0.015 --recordNMSE"
+--seedsPerVoxel 1  --numTensor 2  --numThreads 1 --minBranchingAngle 0.0 --maxBranchingAngle 0.0 --stoppingFA 0.10 --stoppingThreshold 0.05 --Qm 0.001 --Ql 10 --Rs 0.015 --recordNMSE"
 eval $my_command
 # 
 ## 2T - fw
 diff_im_path='Data/Input/two_tensor_fw.nhdr'
 output_path='Data/Baseline/2T_fw_fiber.vtk'
 my_command="$ukf_path --dwiFile $diff_im_path --maskFile $mask_path --tracts $output_path --seedsFile $seeds_path 
---seedsPerVoxel 1  --numTensor 2  --numThreads 1 --minBranchingAngle 0.0 --maxBranchingAngle 0.0 --freeWater --recordFreeWater --recordNMSE --minFA 0.10 --minGA 0.05 --Qm 0.01 --Ql 10 --Rs 0.015" 
+--seedsPerVoxel 1  --numTensor 2  --numThreads 1 --minBranchingAngle 0.0 --maxBranchingAngle 0.0 --freeWater --recordFreeWater --recordNMSE --stoppingFA 0.10 --stoppingThreshold 0.05 --Qm 0.01 --Ql 10 --Rs 0.015"
 eval $my_command
  

--- a/ukf/UKFTractography.cxx
+++ b/ukf/UKFTractography.cxx
@@ -51,12 +51,34 @@ int main(int argc, char **argv)
 {
 
   PARSE_ARGS ;
-  ukfPrecisionType l_minFA = minFA;
-  ukfPrecisionType l_minGA = minGA;
+
+  /* Begin deprecation section */
+  {
+  /*
+  *  Check for and print warning about invalid parameter `minGA`
+  *
+  *  GA is no longer used as a tracking threshold.
+  *
+  *  Please see the following for more information:
+  *   https://github.com/pnlbwh/ukftractography/pull/64
+  *   https://github.com/pnlbwh/ukftractography/pull/75
+  *
+  */
+
+    if (minGAArg.isSet())
+      {
+      std::cerr << "Error: the `minGA` parameter is no longer valid because GA is not used! Please use 'stoppingThreshold' instead! Please see `--help` for more information" << std::endl;
+      exit(1);
+      }
+  }
+  /* End deprecation section */
+
+  ukfPrecisionType l_stoppingFA = stoppingFA;
+  ukfPrecisionType l_stoppingThreshold = stoppingThreshold;
   ukfPrecisionType l_stepLength = stepLength;
   ukfPrecisionType l_recordLength = recordLength;
   ukfPrecisionType l_maxHalfFiberLength = maxHalfFiberLength;
-  ukfPrecisionType l_seedFALimit = seedFALimit;
+  ukfPrecisionType l_seedingThreshold = seedingThreshold;
   ukfPrecisionType l_Qm = Qm;
   ukfPrecisionType l_Ql = Ql;
   ukfPrecisionType l_Qw = Qw;
@@ -164,16 +186,16 @@ int main(int argc, char **argv)
     labels.push_back(1) ;	//Default to use label 1
   }
 
-  if (l_minFA == 0.15) {
-    setAndTell(l_minFA, l_minFA, "minFA");
+  if (l_stoppingFA == 0.15) {
+    setAndTell(l_stoppingFA, l_stoppingFA, "stoppingFA");
   } else {
-    tell(l_minFA, "minFA");
+    tell(l_stoppingFA, "stoppingFA");
   }
 
-  if (l_seedFALimit == 0.0) {
-    setAndTell(l_seedFALimit, FULL_BRAIN_GA_MIN, "seedFALimit");  // Used to default to 2 times the FA threshold.
+  if (l_seedingThreshold == 0.0) {
+    setAndTell(l_seedingThreshold, FULL_BRAIN_GA_MIN, "seedingThreshold");  // Used to default to 2 times the FA threshold.
   } else {
-    tell(l_seedFALimit, "seedFALimit");
+    tell(l_seedingThreshold, "seedingThreshold");
   }
 
   if(!noddi){
@@ -284,7 +306,7 @@ int main(int argc, char **argv)
       }
     }
 
-  tell(l_minGA, "minGA");
+  tell(l_stoppingThreshold, "stoppingThreshold");
 
   if (seedsPerVoxel == 1) {
     std::cout << "- seedsPerVoxel: " << seedsPerVoxel << std::endl;
@@ -394,7 +416,7 @@ int main(int argc, char **argv)
                                          recordVic, recordKappa, recordViso,
                                          !noTransformPosition, storeGlyphs, branchesOnly,
 
-                                         l_minFA, l_minGA, l_seedFALimit,
+                                         l_stoppingFA, l_stoppingThreshold, l_seedingThreshold,
                                          numTensor, seedsPerVoxel,
                                          l_minBranchingAngle, l_maxBranchingAngle,
                                          !simpleTensorModel, freeWater, noddi,

--- a/ukf/UKFTractography.xml
+++ b/ukf/UKFTractography.xml
@@ -80,8 +80,10 @@
     </integer>
 
     <double>
-      <name>seedFALimit</name>
-      <longflag>seedFALimit</longflag>
+      <name>seedingThreshold</name>
+      <longflag deprecatedalias="seedFALimit">
+        seedingThreshold
+      </longflag>
       <label>Seeding: Minimum seed FA</label>
       <description>Tractography parameter used in all models. Seed points whose fractional anisotropy (FA) are below this value are excluded. Default: 0.18. Range: 0-1.</description>
       <default>0.18</default>
@@ -93,8 +95,10 @@
     </double>
 
     <double>
-      <name>minFA</name>
-      <longflag>minFA</longflag>
+      <name>stoppingFA</name>
+      <longflag deprecatedalias="minFA">
+        stoppingFA
+      </longflag>
       <label>Stopping Criterion: Terminating FA</label>
       <description>Tractography parameter used in tensor model. Tractography will stop when the fractional anisotropy (FA) of the tensor being tracked is less than this value. Note: make sure to also decrease the GA to track through lower anisotropy areas. This parameter is used only in tensor models. Default: 0.15. Range: 0-1.</description>
       <default>0.15</default>
@@ -106,16 +110,16 @@
     </double>
 
     <double>
-      <name>minGA</name>
-      <longflag>minGA</longflag>
-      <label>Stopping Criterion: Terminating GA </label>
-      <description>Tractography parameter used in all models. Tractography will stop when the generalized anisotropy (GA) is less than this value. GA is a normalized variance of the input signals (so it does not depend on any model). Note: to extend tracking through low anisotropy areas, this parameter is often more effective than the minFA. This parameter is used by both tensor and NODDI models. Default: 0.1. Range: 0-1. </description>
+      <name>stoppingThreshold</name>
+      <longflag>stoppingThreshold</longflag>
+      <label>Stopping Criterion: Terminating mean signal</label>
+      <description>Tractography parameter used in all models. Tractography will stop when the mean signal is below this value. Default: 0.1. Range: 0-1. </description>
       <default>0.1</default>
       <constraints>
-    <minimum>0</minimum>
-      <maximum>1</maximum>
-      <step>0.01</step>
-    </constraints>
+        <minimum>0</minimum>
+        <maximum>1</maximum>
+        <step>0.01</step>
+      </constraints>
     </double>
 
     <integer>
@@ -444,6 +448,24 @@
       <default>false</default>
     </boolean>
 
+<!-- DEPRECATED-REMOVED: we will print an error and deprecation notice because this GA threshold is no
+                         longer available.
+                         for changes see: https://github.com/pnlbwh/ukftractography/pull/64  -->
+
+    <double hidden="true">
+      <name>minGA</name>
+      <longflag>minGA</longflag>
+      <label>DEPRECATED REMOVED: minGA (was Stopping Criterion: Terminating GA)</label>
+      <description>
+        <![CDATA[DEPRECATED REMOVED: this parameter is no longer valid! Please use 'stoppingThreshold' instead! GA is no longer used as a stopping threshold. Please see https://github.com/pnlbwh/ukftractography/pull/64 for more information. (Was: Tractography parameter used in all models. Tractography will stop when the generalized anisotropy (GA) is less than this value. GA is a normalized variance of the input signals (so it does not depend on any model). Note: to extend tracking through low anisotropy areas, this parameter is often more effective than the minFA. This parameter is used by both tensor and NODDI models. Default: 0.1. Range: 0-1.)]]>
+      </description>
+      <default>0.1</default>
+      <constraints>
+        <minimum>0</minimum>
+        <maximum>1</maximum>
+        <step>0.01</step>
+      </constraints>
+    </double>
 
 </parameters>
 


### PR DESCRIPTION
- `minFA` -> `stoppingFA` (with deprecationalias)
- `seedFALimit` -> `seedingThreshold` (with deprecationalias)

- `minGA` -> `stoppingThreshold` (**error message will be printed for `minGA`**)
  (GA is no longer used as a tracking threshold, so this parameter name is not valid. See here for more information: #64)

cc @yrathi @ljod