### PR TITLE
WIP: Use raw mask value instead of interpolated

### DIFF
--- a/ukf/ISignalData.h
+++ b/ukf/ISignalData.h
@@ -47,6 +47,9 @@ public:
   /** Checks if a certian position is still within the brain mask. */
   virtual ukfPrecisionType Interp3ScalarMask(const vec3_t& pos) const = 0;
 
+  /** Checks if a certian position is still within the brain mask. */
+  virtual ukfPrecisionType ScalarMaskValue(const vec3_t& pos) const = 0;
+
   /** Get all the seed points. */
   virtual void GetSeeds(const std::vector<int>& labels, stdVec_t& seeds) const = 0;
 

--- a/ukf/NrrdData.cc
+++ b/ukf/NrrdData.cc
@@ -117,6 +117,45 @@ void NrrdData::Interp3Signal(const vec3_t& pos,
 
 }
 
+ukfPrecisionType NrrdData::ScalarMaskValue(const vec3_t& pos) const
+{
+  const int nx = static_cast<const int>(_dim[0]);
+  const int ny = static_cast<const int>(_dim[1]);
+  const int nz = static_cast<const int>(_dim[2]);
+
+  unsigned int index;
+  ukfPrecisionType       value;
+
+  ukfPrecisionType w_sum = 1e-16;
+  ukfPrecisionType s = ukfZero;
+
+
+  const int x = static_cast<const int>(round(pos[0]));
+  const int y = static_cast<const int>(round(pos[1]));
+  const int z = static_cast<const int>(round(pos[2]));
+  index = nz * ny * x + nz * y + z;
+
+  // signed or unsigned doesn't make a difference since masks don't contain any negative values
+  switch( _mask_num_bytes )
+    {
+    case 1:
+      {
+      value = static_cast<char *>(_mask_data)[index];
+      }
+      break;
+    case 2:
+      {
+      value = static_cast<short *>(_mask_data)[index];
+      }
+      break;
+    default:
+      std::cout << "Unsupported data type for seed file!" << std::endl;
+      exit(1);
+    }
+
+  return value;
+}
+
 ukfPrecisionType NrrdData::Interp3ScalarMask(const vec3_t& pos) const
 {
   const int nx = static_cast<const int>(_dim[0]);

--- a/ukf/NrrdData.h
+++ b/ukf/NrrdData.h
@@ -36,6 +36,9 @@ public:
   /** Interpolates the brain mask at a certain position */
   virtual ukfPrecisionType Interp3ScalarMask(const vec3_t& pos) const;
 
+  /** Gets brain mask value at a certain position */
+  virtual ukfPrecisionType ScalarMaskValue(const vec3_t& pos) const;
+
   /**
    * \brief Get the seed points from the nrrd file
    *

--- a/ukf/tractography.cc
+++ b/ukf/tractography.cc
@@ -201,7 +201,7 @@ void Tractography::Init(std::vector<SeedPointInfo>& seed_infos)
         for( int z = 0; z < dim[2]; ++z )
           {
           vec3_t pos(x,y,z); //  = make_vec(x, y, z);
-          if( _signal_data->Interp3ScalarMask(pos) > 0.1 )
+          if(_signal_data->ScalarMaskValue(pos) > 0)
             {
             seeds.push_back(pos);
             }
@@ -872,7 +872,7 @@ void Tractography::Follow3T(const int thread_id,
     // Check if we should abort following this fiber. We abort if we reach the
     // CSF, if FA or GA get too small, if the curvature get's too high or if
     // the fiber gets too long.
-    const bool is_brain = _signal_data->Interp3ScalarMask(x) > 0.1;
+    const bool is_brain = _signal_data->ScalarMaskValue(x) > 0; //_signal_data->Interp3ScalarMask(x) > 0.1;
 
     state_tmp.col(0) = state;
     _model->H(state_tmp, signal_tmp);
@@ -1068,7 +1068,7 @@ void Tractography::Follow2T(const int thread_id,
     // Check if we should abort following this fiber. We abort if we reach the
     // CSF, if FA or GA get too small, if the curvature get's too high or if
     // the fiber gets too long.
-    const bool is_brain = _signal_data->Interp3ScalarMask(x) > 0.1; // is this 0.1 correct? yes
+    const bool is_brain = _signal_data->ScalarMaskValue(x) > 0; // _signal_data->Interp3ScalarMask(x) > 0.1; // is this 0.1 correct? yes
 
     // after here state does not change until next step.
 
@@ -1194,7 +1194,7 @@ void Tractography::Follow1T(const int thread_id,
     Step1T(thread_id, x, fa, state, p, dNormMSE, trace);
 
     // Terminate if off brain or in CSF.
-    const bool is_brain = _signal_data->Interp3ScalarMask(x) > 0.1; // x is the seed point
+    const bool is_brain = _signal_data->ScalarMaskValue(x) > 0; //_signal_data->Interp3ScalarMask(x) > 0.1; // x is the seed point
     state_tmp.col(0) = state;
 
     _model->H(state_tmp, signal_tmp);


### PR DESCRIPTION
Changes tracing termination criteria to use raw mask value rather than interpolation, which caused some fibers to apparently terminate outside of mask. Fixes #81.

Before:

![image](https://user-images.githubusercontent.com/327706/28380029-cfa942de-6c83-11e7-8a13-152aaf5b3d24.png)

After:
![image](https://user-images.githubusercontent.com/327706/28380054-df4a468e-6c83-11e7-9ac3-5eaa863d7557.png)