### PR TITLE
WIP: COMP: clean up error handling; exit -> throw, and catch where needed

### DIFF
--- a/CompressedSensing/SphericalHarmonics.cxx
+++ b/CompressedSensing/SphericalHarmonics.cxx
@@ -97,7 +97,7 @@ MatrixType SphericalHarmonics(const MatrixType &u, unsigned  m)
   if(m != 22)
     {
     std::cerr << "Have to rebuild SphericalHarmonicsConst.h from Matlab" << std::endl;
-    exit(1);
+    throw;
     }
   unsigned long cols = (m+1)*(m+1);
   MatrixType rval(u.rows(),cols);

--- a/ukf/NrrdData.cc
+++ b/ukf/NrrdData.cc
@@ -154,7 +154,7 @@ ukfPrecisionType NrrdData::ScalarMaskValue(const vec3_t& pos) const
       break;
     default:
       std::cout << "Unsupported data type for seed file!" << std::endl;
-      exit(1);
+      throw;
     }
 
   return value;
@@ -217,7 +217,7 @@ ukfPrecisionType NrrdData::Interp3ScalarMask(const vec3_t& pos) const
             break;
           default:
             std::cout << "Unsupported data type for seed file!" << std::endl;
-            exit(1);
+            throw;
           }
 
         ukfPrecisionType w = std::exp(-(dxx + dyy + dzz) / _sigma_mask);
@@ -375,7 +375,7 @@ bool NrrdData::LoadData(const std::string& data_file,
     std::cout
     << "This implementation only accepts masks of type 'signed char', 'unsigned char', 'short', and 'unsigned short'\n";
     std::cout << "Convert your mask using 'unu convert' and rerun.\n";
-    exit(1);
+    throw;
     }
 
   _mask_data = _mask_nrrd->data;

--- a/ukf/QuadProg++_Eigen.cc
+++ b/ukf/QuadProg++_Eigen.cc
@@ -272,7 +272,6 @@ void cholesky_decomposition(ukfMatrixType& A)
           std::cout << "A" << A;
           os << "Error in cholesky decomposition, sum: " << sum;
           throw std::logic_error(os.str() );
-          exit(-1);
           }
         A(i,i) = ::std::sqrt(sum);
         }

--- a/ukf/UKFTractography.cxx
+++ b/ukf/UKFTractography.cxx
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
   if(!noddi){
     if(recordVic || recordKappa || recordViso){
       std::cout << "Can use recordVic or recordKappa or recordViso parameters only with noddi model";
-      exit(1);
+      return EXIT_FAILURE;
     }
   }
 
@@ -340,7 +340,7 @@ int main(int argc, char **argv)
   if (std::abs(weight_accumu - 1.0) > 0.000001)
     {
     std::cout << "The weights on different tensors must add up to 1!" << std::endl << std::endl ;
-    exit(1) ;
+    return EXIT_FAILURE;
     }
   else
     {
@@ -449,17 +449,32 @@ int main(int argc, char **argv)
 
     // Run the tractography.
     writeStatus = tract->Run();
+    std::cout << "H count = " << countH << std::endl;
     }
   catch( itk::ExceptionObject & err )
     {
-    std::cerr << "ITK ExceptionObject caught!" << std::endl;
+    std::cerr << "UKFTractography: ITK ExceptionObject caught!" << std::endl;
     std::cerr << err << std::endl;
+
+    writeStatus = EXIT_FAILURE;
+    }
+  catch( std::exception& exc )
+    {
+    std::cerr << "UKFTractography: std::exception caught:" << std::endl;
+    std::cerr << exc.what() << std::endl;
+
+    writeStatus = EXIT_FAILURE;
+    }
+  catch(...)
+    {
+    std::cerr << "UKFTractography: Unknown exception caught!" << std::endl;
+
+    writeStatus = EXIT_FAILURE;
     }
 
   // Clean up.
   delete tract;
   delete filter_model;
 
-  std::cout << "H count = " << countH << std::endl;
   return writeStatus;
 }

--- a/ukf/dwi_normalize.cc
+++ b/ukf/dwi_normalize.cc
@@ -21,7 +21,7 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
   if( raw->dim != static_cast<unsigned int>(DATA_DIMENSION) )
     {
     std::cout << "The dimension of the nrrd data must be " << DATA_DIMENSION << "!" << std::endl;
-    exit(1);
+    throw;
     }
 
   // Check the world coordinate frame
@@ -32,7 +32,7 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
     )
     {
     std::cout << "Can only handle RAS, LAS and LPS world coordinate frames!" << std::endl;
-    exit(1);
+    throw;
     }
 
   if( nrrdConvert(normalized, raw, nrrdTypeFloat) )    // NOTICE that in the current version of teem, all the key/value
@@ -42,7 +42,7 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
     char *txt = biffGetDone(NRRD);
     std::cout << txt << std::endl;
     free( txt );
-    exit(1);
+    throw;
     }
 
   nrrdKeyValueClear(normalized);  // Force to erase the key/value pairs
@@ -62,7 +62,7 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
       if( 3 != sscanf(value, "%50f %50f %50f", &gx, &gy, &gz) )
         {
         std::cout << "The gradients must have 3 components!" << std::endl;
-        exit(1);
+        throw;
         }
       const float gradient_magnitude = sqrt(gx * gx + gy * gy + gz * gz);
       nonZeroGradientFlag.push_back( gradient_magnitude > 0.05F );
@@ -88,12 +88,12 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
   if( numNonZeroGradients == 0 )
     {
     std::cout << "No valid gradients in the data!" << std::endl;
-    exit(1);
+    throw;
     }
   if( numZeroGradients == 0 )
     {
     std::cout << "No zero gradients!" << std::endl;
-    exit(1);
+    throw;
     }
 
   std::cout << "Number of non-zero gradients: " << numNonZeroGradients << std::endl;
@@ -109,20 +109,20 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
       if( listAxis != -1 )
         {
         std::cout << "Too many list axes in the data!" << std::endl;
-        exit(1);
+        throw;
         }
       listAxis = i;
       }
     else if( normalized->axis[i].kind != nrrdKindDomain && normalized->axis[i].kind != nrrdKindSpace )
       {
       std::cout << "Unrecognizable axis kind: axis " << i << " is of kind " << normalized->axis[i].kind << std::endl;
-      exit(1);
+      throw;
       }
     }
   if( listAxis == -1 )
     {
     std::cout << "Can not find the list axis!" << std::endl;
-    exit(1);
+    throw;
     }
 
   assert(nonZeroGradientFlag.size() == normalized->axis[listAxis].size);
@@ -157,7 +157,7 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
     char *txt = biffGetDone(NRRD);
     std::cout << txt << std::endl;
     free( txt );
-    exit(1);
+    throw;
     }
   nrrdNuke(normalized);
   normalized = temp;
@@ -186,7 +186,7 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
     char *txt = biffGetDone(NRRD);
     std::cout << txt << std::endl;
     free( txt );
-    exit(-1);
+    throw;
     }
 
   // Average the baseline image
@@ -272,7 +272,7 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
         if( nrrdKeyValueAdd(normalized, ss.str().c_str(), keyValuePairsOfRaw[i].second.c_str() ) )
           {
           std::cout << "Error while adding key/value pairs!" << std::endl;
-          exit(1);
+          throw;
           }
         }
       totalGradientCounter++;       // No output for 0 gradients to the normalized data
@@ -285,7 +285,7 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
         char *txt = biffGetDone(NRRD);
         std::cout << txt << std::endl;
         free( txt ); //Values allocated by Nrrd should be removed with free.
-        exit(1);
+        throw;
         }
       }
     }

--- a/ukf/filter_Simple1T_FW.cc
+++ b/ukf/filter_Simple1T_FW.cc
@@ -77,13 +77,13 @@ void Simple1T_FW::H(const ukfMatrixType& X,
       {
       std::cout << "Negative weight! w= " << w << "\n";
       std::cout << X << "\ni: " << i;
-      exit(1);
+      throw;
       }
     if( w > 1 + 1.0e-5 )
       {
       std::cout << "Weight > 1 => negative free water! w= " << w << "\n";
       std::cout << X << "\ni: " << i;
-      exit(1);
+      throw;
       }
 
     // Flip if necessary.

--- a/ukf/filter_model.cc
+++ b/ukf/filter_model.cc
@@ -20,7 +20,7 @@ ukfPrecisionType FilterModel::CheckZero(const ukfPrecisionType & local_d) const
     else   // for errors too big exit with exception
       {
       std::cout << "Error, a variable became negative. Most likely something went wrong in the QP\n";
-      exit(1);
+      throw;
       }
     }
   return local_d;

--- a/ukf/tractography.cc
+++ b/ukf/tractography.cc
@@ -81,13 +81,13 @@ Tractography::Tractography(FilterModel *model, model_type filter_model_type,
   if( _cos_theta_max != ukfZero && _cos_theta_max <= _cos_theta_min )
     {
     std::cout << "Maximum branching angle must be greater than " << minBranchingAngle << " degrees." << std::endl;
-    exit(1);
+    throw;
     }
 
   if( _num_tensors < 1 || _num_tensors > 3 )
     {
     std::cout << "Only one, two or three tensors are supported." << std::endl;
-    exit(1);
+    throw;
     }
 
   _cos_theta_max = std::cos( DegToRad( _cos_theta_max ) );
@@ -1480,7 +1480,7 @@ void Tractography::Step2T(const int thread_id,
   // file.
   // This coordinate order is filpped back during output
   // The step length is in World space
-  // exit(1);
+  // throw;
 }
 
 void Tractography::Step1T(const int thread_id,
@@ -1662,7 +1662,7 @@ void Tractography::Record(const vec3_t& x, const ukfPrecisionType fa, const ukfP
       else   // for too big errors exit with exception.
         {
         std::cout << "Error: program produced negative free water.\n";
-        exit(1);
+        throw;
         }
       }
     fiber.free_water.push_back(viso);
@@ -1683,7 +1683,7 @@ void Tractography::Record(const vec3_t& x, const ukfPrecisionType fa, const ukfP
       else   // for too big errors exit with exception.
         {
         std::cout << "Error: program produced negative free water.\n";
-        exit(1);
+        throw;
         }
       }
     fiber.free_water.push_back(fw);

--- a/ukf/unscented_kalman_filter.cc
+++ b/ukf/unscented_kalman_filter.cc
@@ -88,7 +88,7 @@ void UnscentedKalmanFilter::Constrain(ukfVectorType& x, const ukfMatrixType& W)
     const ukfPrecisionType error = solve_quadprog(W_tmp, g0, m_DummyZeroCE, m_DummyZeroce0, D, d, x);
     if( error > 0.01 )   // error usually much smaller than that, if solve_quadprog fails it returns inf
       {
-      exit(1);
+      throw std::logic_error("solve_quadprog error exceeds threshold 0.01!");
       }
     }
 }
@@ -169,7 +169,7 @@ void UnscentedKalmanFilter::Filter(const State& x,
   /** Used for the estimation of the new state */
   ukfMatrixType dim_dimext(dim, 2 * dim + 1);
   dim_dimext.setConstant(ukfZero);
-  // std::cout << "\n X:"<<X <<"\n Weigths" << this->m_Weights;  
+  // std::cout << "\n X:"<<X <<"\n Weigths" << this->m_Weights;
   const ukfVectorType X_hat = X * this->m_Weights;
   for( unsigned int i = 0; i < dim_dimext.cols(); ++i )
     {

--- a/vtk2mask/vtk2mask.cxx
+++ b/vtk2mask/vtk2mask.cxx
@@ -32,13 +32,13 @@ int main(int argc, char* argv[]) {
   if (  OutputVolume.empty() )
   {
     std::cout << "No output volume specified! Set the --OutputVolume option." << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   if (  ReferenceFile.empty() )
   {
     std::cout << "No reference volume specified! Set the --ReferenceFile option." << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   std::vector<Fiber> in_fibers;
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
   // SOME ADDITIONAL CHECKS ///////////////////////////////////////////////////
   if (in_fibers.size() == 0) {
     std::cout << "The fiber file is empty. Exiting..." << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   if (ScalarName.empty()) {

--- a/vtkFilter/ExpressionEvaluator.cc
+++ b/vtkFilter/ExpressionEvaluator.cc
@@ -153,7 +153,7 @@ std::vector<Fiber> ExpressionEvaluator::evaluateOperand(char operand)
       break;
     default:
       std::cout << "error!\n";
-      exit(1);
+      return EXIT_FAILURE;
     }
 
   _filter->Run();

--- a/vtkFilter/FiberFilter.cc
+++ b/vtkFilter/FiberFilter.cc
@@ -155,6 +155,5 @@ bool FiberFilter::CheckConditions(const Fiber & fiber)
     }
 
   std::cout << "Error: Should never reach this point!\n";
-  exit(1);
-
+  throw;
 }


### PR DESCRIPTION
This allows libUKF called as a shared library to print errors rather than generic thread-exit message from the CLI runner, and avoids Slicer crashes in some cases (unrelated to UKF, as far as I can tell).