### PR TITLE
Fix slicer CLI usage, and add conditional CLI test.

### DIFF
--- a/ukf/Testing/CMakeLists.txt
+++ b/ukf/Testing/CMakeLists.txt
@@ -1,5 +1,3 @@
-#set(BASELINE ${CMAKE_CURRENT_SOURCE_DIR}/../../Data/Baseline)
-#set(INPUT ${CMAKE_CURRENT_SOURCE_DIR}/../../Data/Input)
 get_filename_component(INPUT ${CMAKE_CURRENT_SOURCE_DIR}/../Data/Input REALPATH)
 get_filename_component(BASELINE ${CMAKE_CURRENT_SOURCE_DIR}/../Data/Baseline REALPATH)
 set(TESTING_RESULTS_DIRECTORY "${CMAKE_BINARY_DIR}/Testing/Temporary")
@@ -374,3 +372,27 @@ add_test(NAME ${testname}Compare
 
 set_property(TEST ${testname}Compare PROPERTY LABELS ConvertVTK)
 set_tests_properties(${testname}Compare PROPERTIES DEPENDS ${testname})
+
+###############################################################################
+# UKF Slicer CLI Test
+###############################################################################
+if (${UKFTractography_BUILD_SLICER_EXTENSION})
+    if (MSVC) # need release subdir on Windows :|
+      set(REL_VAR "/Release")
+    else()
+      set(REL_VAR "")
+    endif()
+
+  set(UKF_UNITTEST_LIB_PATHS "--additional-module-paths;${CMAKE_BINARY_DIR}/${Slicer_QTSCRIPTEDMODULES_LIB_DIR}${REL_VAR};${CMAKE_BINARY_DIR}/${Slicer_QTLOADABLEMODULES_LIB_DIR}${REL_VAR};${CMAKE_BINARY_DIR}/${Slicer_CLIMODULES_LIB_DIR}${REL_VAR}")
+
+    set(UKF_TEST_CLI_PYTHON "${CMAKE_CURRENT_SOURCE_DIR}/slicer_cli_test.py")
+
+    set(testname UKF_Slicer_CLI)
+    add_test(
+      NAME ${testname}
+      COMMAND ${Slicer_LAUNCHER_EXECUTABLE}
+      ${UKF_UNITTEST_LIB_PATHS}
+      --python-code "data_dir = '${INPUT}'; execfile('${UKF_TEST_CLI_PYTHON}')"
+      )
+
+endif()

--- a/ukf/Testing/slicer_cli_test.py
+++ b/ukf/Testing/slicer_cli_test.py
@@ -1,0 +1,56 @@
+from __future__ import print_function
+
+import sys, os
+
+
+#
+# Get widgets and set test parameters
+#
+
+cli_widget = slicer.modules.ukftractography.widgetRepresentation()
+
+dwi_selector = findChild(cli_widget, "dwiFile")
+tck_selector = findChild(cli_widget, "tracts")
+msk_selector = findChild(cli_widget, "maskFile")
+lbl_selector = findChild(cli_widget, "seedsFile")
+
+# make sure selectors exist
+if not (tck_selector and dwi_selector and tck_selector and lbl_selector):
+  print("Error: Unable to get selector combo box(es) from CLI widget!", file=sys.stderr)
+  slicer.util.exit(1)
+
+#
+# Load test data
+#
+
+slicer.util.loadVolume(os.path.join(data_dir, "two_tensor_fw.nhdr"))
+slicer.util.loadVolume(os.path.join(data_dir, "mask.nhdr"))
+slicer.util.loadVolume(os.path.join(data_dir, "seed.nhdr"))
+
+dwi_selector.setCurrentNode(getNode("two_tensor_fw"))
+msk_selector.setCurrentNode(getNode("mask"))
+lbl_selector.setCurrentNode(getNode("seed"))
+
+# Hack the node type here and create output node.
+# Avoids dependency for vtkMRMLFiberBundleNode.
+
+tck_selector.nodeTypes = (u'vtkMRMLModelNode',)
+tck_selector.addNode()
+
+#
+# Run the CLI
+#
+cli_mod_node = cli_widget.currentCommandLineModuleNode()
+# run synchronously
+cli_widget.module().cliModuleLogic().ApplyAndWait(cli_mod_node)
+result = cli_mod_node.GetStatus()
+
+#
+# Return exit status for CTest
+#
+
+if result != cli_mod_node.Completed:
+  print("Error: CLI completed with errors!", file=sys.stderr)
+  slicer.util.exit(1)
+
+slicer.util.exit(0)

--- a/ukf/UKFTractography.cxx
+++ b/ukf/UKFTractography.cxx
@@ -65,10 +65,14 @@ int main(int argc, char **argv)
   *
   */
 
-    if (minGAArg.isSet())
+    // check infeasible default value as work-around because
+    // Slicer CLI generates command line arguments for all
+    // parameters, and the CLP doesn't indicate no-arg
+
+    if (minGAArg.isSet() && minGA != 10000)
       {
-      std::cerr << "Error: the `minGA` parameter is no longer valid because GA is not used! Please use 'stoppingThreshold' instead! Please see `--help` for more information" << std::endl;
-      exit(1);
+      std::cerr << "Error: the `minGA` parameter is no longer valid because GA is not used! Please use 'stoppingThreshold' instead! Please see `--help` for more information." << std::endl;
+      return EXIT_FAILURE;
       }
   }
   /* End deprecation section */

--- a/ukf/UKFTractography.xml
+++ b/ukf/UKFTractography.xml
@@ -453,17 +453,16 @@
                          for changes see: https://github.com/pnlbwh/ukftractography/pull/64  -->
 
     <double hidden="true">
-      <name>minGA</name>
       <longflag>minGA</longflag>
       <label>DEPRECATED REMOVED: minGA (was Stopping Criterion: Terminating GA)</label>
       <description>
         <![CDATA[DEPRECATED REMOVED: this parameter is no longer valid! Please use 'stoppingThreshold' instead! GA is no longer used as a stopping threshold. Please see https://github.com/pnlbwh/ukftractography/pull/64 for more information. (Was: Tractography parameter used in all models. Tractography will stop when the generalized anisotropy (GA) is less than this value. GA is a normalized variance of the input signals (so it does not depend on any model). Note: to extend tracking through low anisotropy areas, this parameter is often more effective than the minFA. This parameter is used by both tensor and NODDI models. Default: 0.1. Range: 0-1.)]]>
       </description>
-      <default>0.1</default>
       <constraints>
         <minimum>0</minimum>
         <maximum>1</maximum>
-        <step>0.01</step>
+          <step>0.01</step>
+        <default>10000</default>
       </constraints>
     </double>
 


### PR DESCRIPTION
Slicer CLI automatically adds all parameters, so 'minGAArg' check from #75 always hits deprecation error. Work around this by setting out-of-range default value in CLI XML, and check for that value to indicate running under Slicer CLI defaults.

Also add test for basic CLI usage (only executed when built as Slicer extension).