### PR TITLE
COMP: fix extension superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,14 @@ option(${PRIMARY_PROJECT_NAME}_SUPERBUILD "Build ${PRIMARY_PROJECT_NAME} and the
 mark_as_advanced(${PRIMARY_PROJECT_NAME}_SUPERBUILD)
 
 #-----------------------------------------------------------------------------
+# Required by Slicer extension build system for reasons. See
+#    https://github.com/Slicer/Slicer/commit/b160ec13f276a86306513954ef8b08a5332afc2e
+set(CPACK_INSTALL_CMAKE_PROJECTS "${CPACK_INSTALL_CMAKE_PROJECTS};${CMAKE_BINARY_DIR};${PROJECT_NAME};RuntimeLibraries;/")
+
+#-----------------------------------------------------------------------------
 # Superbuild script
 #-----------------------------------------------------------------------------
+
 if(${PRIMARY_PROJECT_NAME}_SUPERBUILD)
   project(SuperBuild_${PRIMARY_PROJECT_NAME})  # <- NOTE: Project name for pre-requisites is different form main project
   include("${CMAKE_CURRENT_SOURCE_DIR}/SuperBuild.cmake")
@@ -80,6 +86,4 @@ else()
   include("${CMAKE_CURRENT_SOURCE_DIR}/${PRIMARY_PROJECT_NAME}.cmake")
   return()
 endif()
-
 message(FATAL_ERROR "You should never reach this point !")
-


### PR DESCRIPTION
The extension build system now requires this variable to be set. See

https://github.com/Slicer/Slicer/commit/b160ec13f276a86306513954ef8b08a5332afc2e