### PR TITLE
Export fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # emacs cruft
 *~
+
+# macOS cruft
+.DS_Store

--- a/common/ukf_exports.h
+++ b/common/ukf_exports.h
@@ -1,0 +1,31 @@
+/*=auto=========================================================================
+
+ Portions (c) Copyright 2005 Brigham and Women's Hospital (BWH)
+ All Rights Reserved.
+
+ See COPYRIGHT.txt
+ or http://www.slicer.org/copyright/copyright.txt for details.
+
+ Program:   3D Slicer
+
+=========================================================================auto=*/
+
+
+// .NAME __UKFExport - manage Windows system differences
+// .SECTION Description
+// The __UKFExport captures some system differences between Unix
+// and Windows operating systems.
+
+#ifndef __UKFExport_h
+#define __UKFExport_h
+
+#if defined(WIN32) && !defined(UKF_STATIC)
+ #if defined(UKF_EXPORTS)
+  #define UKFTRACTOGRAPHYLIB_EXPORT __declspec( dllexport )
+ #else
+  #define UKFTRACTOGRAPHYLIB_EXPORT __declspec( dllimport )
+ #endif
+#else
+ #define UKFTRACTOGRAPHYLIB_EXPORT
+#endif
+#endif

--- a/ukf/tractography.h
+++ b/ukf/tractography.h
@@ -11,7 +11,7 @@
 #include "ukffiber.h"
 #include "seed.h"
 #include "ukf_types.h"
-#include "ukftractographylib_export.h"
+#include "ukf_exports.h"
 
 class NrrdData;
 class vtkPolyData;


### PR DESCRIPTION
The header definition used to be generated at build time by a Slicer cmake macro, but that is not necessary.

(also add macOS `.DS_Store` nonsense to `.gitignore`)