### PR TITLE
COMP: Fix configuration warning setting CMP0074 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
+
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW) #3.12.0 `find_package()`` uses ``<PackageName>_ROOT`` variables.
+endif()
+
 #-----------------------------------------------------------------------------
 # Enable C++11
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This commit addresses the following warning:

```
  CMake Warning (dev) at UKFTractography.cmake:62 (find_package):
    Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
    Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
    command to set the policy and suppress this warning.

    CMake variable ZLIB_ROOT is set to:

      /path/to/zlib-install

    For compatibility, CMake is ignoring the variable.
  Call Stack (most recent call first):
    CMakeLists.txt:84 (include)
  This warning is for project developers.  Use -Wno-dev to suppress it.
```