### PR TITLE
COMP: Fix microsoft compiler link error related to _hypot symbol

### DIFF
--- a/common/linalg.h
+++ b/common/linalg.h
@@ -7,10 +7,6 @@
 #ifndef LINALG_H_
 #define LINALG_H_
 
-#if defined(WIN32)
-#define hypot _hypot
-#endif
-
 #include <cmath>
 #include "ukf_types.h"
 

--- a/common/ukf_exports.h
+++ b/common/ukf_exports.h
@@ -19,6 +19,14 @@
 #ifndef __UKFExport_h
 #define __UKFExport_h
 
+/** Disable some common warnings in MS VC++ */
+#if defined( _MSC_VER )
+
+// 'identifier' : class 'type' needs to have dll-interface to be used by
+// clients of class 'type2'
+#pragma warning ( disable : 4251 )
+
+#endif
 
 #if defined(WIN32) && !defined(UKF_STATIC)
  #if defined(UKFBase_EXPORTS)


### PR DESCRIPTION
This commit fixes the following error reported when building using
Visual Studio 14 2015:

```
  D:\D\P\Slicer-0-build\ITK\Modules\ThirdParty\VNL\src\vxl\core\vnl/vnl_math.h(217): error C2039: '
  _hypot': is not a member of 'std' [D:\D\P\S-0-E-b\UKFTractography-build\ukf\UKFBase.vcxproj]
```