### PR TITLE
COMP: fix windows build errors

### DIFF
--- a/SuperBuild/External_Boost.cmake
+++ b/SuperBuild/External_Boost.cmake
@@ -74,7 +74,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
 	  list(APPEND Boost_b2_Command toolset=msvc-14.0)
     elseif(MSVC_VERSION GREATER_EQUAL 1910 AND MSVC_VERSION LESS 1920)
 	  list(APPEND Boost_b2_Command toolset=msvc-14.1)
-    elseif(MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1922)
+    elseif(MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1927)
 	  list(APPEND Boost_b2_Command toolset=msvc-14.2)
     else()	
 	  message(FATAL_ERROR "Unknown MSVC compiler version [${MSVC_VERSION}]")

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -6,10 +6,6 @@ set(${proj}_DEPENDENCIES
   ITK
   )
 
-if(Slicer_BUILD_PARAMETERSERIALIZER_SUPPORT)
-  set(${proj}_DEPENDENCIES ${${proj}_DEPENDENCIES} JsonCpp ParameterSerializer)
-endif()
-
 # Include dependent projects if any
 ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj DEPENDS_VAR ${proj}_DEPENDENCIES)
 

--- a/ukf/CMakeLists.txt
+++ b/ukf/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_target(_GEN_GITVER ALL
     COMMAND ${CMAKE_COMMAND} -E echo_append  "const char UKF_GIT_HASH[] = _ukf_str(_UKF_GIT_HASH);" >> "${UKF_GITVER_TEMP}"
 
     # copy to the real file if different
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${UKF_GITVER_TEMP}" "${UKF_GITVER_FILE}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${UKF_GITVER_TEMP}" "${UKF_GITVER_FILE}"
 
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Generating UKF_GIT_HASH"


### PR DESCRIPTION
- include latest visual studio build tools version
in boost build check
- remove double-linking of json libs for parameter serializer
- force copy of git_version.cc since copy_if_different
was not working

https://discourse.slicer.org/t/the-slicerdmri-extension-is-currently-unavailable/12276/21