### PR TITLE
Declare bmax outside for loop

### DIFF
--- a/ukf/dwi_normalize.cc
+++ b/ukf/dwi_normalize.cc
@@ -49,7 +49,10 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
 
   // Process the key/value pairs. Identify the non-zero gradients, namely the non-zero B values
   std::vector<std::pair<std::string, std::string> > keyValuePairsOfRaw;
-  std::vector<bool>                       nonZeroGradientFlag;
+  std::vector<bool> nonZeroGradientFlag;
+
+  int bmax;
+
   for( unsigned int i = 0; i < nrrdKeyValueSize(raw); i++ )
     {
     char *key;
@@ -58,7 +61,6 @@ void dwiNormalize(const Nrrd *raw, Nrrd *& normalized)
     std::string keyStr(key);
 
     // Obtain DWMRI_b-value
-    int bmax;
     if( keyStr.length() == 13 && !keyStr.compare("DWMRI_b-value") )
       {
         sscanf(value, "%d", &bmax);


### PR DESCRIPTION
Declaration of `int bmax` inside the for loop was not an issue for gcc/4.9.2 (CentOS 7 default, Tashrif's workstation), but it was for GCC/7.3.0 (ERIS cluster). The latter could not remember `bmax` in between iterations. `char *value` pointer also came into play in this collusion.

More details and a different fix around `char *value` pointer can be found in comments in PR #137.