### PR TITLE
recording trace fix

### DIFF
--- a/ukf/tractography.cc
+++ b/ukf/tractography.cc
@@ -1897,12 +1897,24 @@ void Tractography::Record(const vec3_t& x, const ukfPrecisionType fa, const ukfP
 
   if( _record_trace || _record_kappa)
     {
-    fiber.trace.push_back(2*(atan(1/trace)/3.14));
-    if( _num_tensors >= 2 )
+    if( _noddi )
       {
-      fiber.trace2.push_back(2*(atan(1/trace2)/3.14));
+      fiber.trace.push_back(2*(atan(1/trace)/3.14));
+      if( _num_tensors >= 2 )
+        {
+        fiber.trace2.push_back(2*(atan(1/trace2)/3.14));
+        }
+      }
+      else
+      {
+      fiber.trace.push_back(trace/1.0e6);
+      if( _num_tensors >= 2 )
+        {
+        fiber.trace2.push_back(trace2/1e6);
+        }
       }
     }
+
 
   if( _record_fa || _record_Vic)
     {


### PR DESCRIPTION
Hi @yrathi 

For 1T and 2T models, recording trace is fixed to be the sum of L1, L2 and L3, divided by 10^6.

Trace values computed in the UKF code and those computed from tensors in Slicer are the same now (with a small difference in the last digits). 
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/7855446/206217932-66e2d611-71ce-4305-941c-6189cd412856.png">
