### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Installation
 
 Checkout from github:
 
-    git clone git://github.com/pnlbwh/ukftractography.git
+    git clone https://github.com/pnlbwh/ukftractography.git
 
 There are 3 ways to build this project from source, as a stand alone
 superbuild, against a Slicer 4 build, and as a Slicer 4 extension build (which


### PR DESCRIPTION
The git clone using the ssh prefix of git:// no longer works and there is no ssh clone available from the main repo. This change is to update to https: clone so that the command works for users trying to clone the repo using the readme instructions.