### PR TITLE
COMP: fixes for Slicer 5.8 (cxx 17)

### DIFF
--- a/InteractiveUKF/Logic/vtkSlicerInteractiveUKFLogic.cxx
+++ b/InteractiveUKF/Logic/vtkSlicerInteractiveUKFLogic.cxx
@@ -232,7 +232,7 @@ void vtkSlicerInteractiveUKFLogic::SetDataNodes(
     return;
     }
 
-  tract->SetData(nrrd, mask, seed, false /*normalizedDWIData*/);
+  tract->SetData(nrrd, mask, false /*normalizedDWIData*/, seed);
   tract->UpdateFilterModelType();
 
   vtkPolyData* pd = vtkPolyData::New();

--- a/ukf/tractography.h
+++ b/ukf/tractography.h
@@ -132,7 +132,7 @@ public:
    * Directly set the data volume pointers
   */
 
-  bool SetData(void* data, void* mask, bool normalizedDWIData, void* seed, void* stop, void* wm, void* gm, void* csf);
+  bool SetData(void* data, void* mask, bool normalizedDWIData, void* seed, void* stop=nullptr, void* wm=nullptr, void* gm=nullptr, void* csf=nullptr);
 
   /**
    * Directly set the seed locations


### PR DESCRIPTION
* added default null pointer values for optional arguments

* fixed argument order for interactive tractography