### PR TITLE
Fix build errors

### DIFF
--- a/fibertractdispersion/fiberbundle.cxx
+++ b/fibertractdispersion/fiberbundle.cxx
@@ -39,7 +39,7 @@ fiberbundle
     {
     Fiber curFiber;
     vtkIdType nPoints;
-    vtkIdType *pts;
+    const vtkIdType *pts;
     if(curLines->GetNextCell(nPoints,pts) == 0)
       {
       break;

--- a/vtk2mask/Converter.h
+++ b/vtk2mask/Converter.h
@@ -12,7 +12,7 @@
 #include "fiber.h"
 
 #include <itkImage.h>
-#include <itkExceptionObject.h>
+#include <itkMacro.h>
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
 #include <itkMetaDataObject.h>

--- a/vtkFilter/FiberFilter.h
+++ b/vtkFilter/FiberFilter.h
@@ -15,7 +15,7 @@
 #include "Region.h"
 
 #include <itkImage.h>
-#include <itkExceptionObject.h>
+#include <itkMacro.h>
 #include <itkImageFileWriter.h>
 #include <itkImageFileReader.h>
 #include <itkMetaDataObject.h>


### PR DESCRIPTION
Addresses #166 

Fixes the following errors:
- ukftractography/fibertractdispersion/fiberbundle.cxx:43:38: `error: binding reference of type ‘const vtkIdType*&’ {aka ‘const long long int*&’} to ‘vtkIdType*’ {aka ‘long long int*’} discards qualifiers`
  - Add `const` qualifier to `vtkIdType *pts` before function call, to match function signature.
- error: "Do not include itkExceptionObject.h directly, include itkMacro.h instead."
  - Swap imports on affected files: [vtk2mask/Converter.h](https://github.com/pnlbwh/ukftractography/compare/update-dependencies...dheshanm:ukftractography:fix-build-errors?expand=1#diff-740e8d7a9c64066e55567c1c125226073b953bf0ced3bce03df27a24402eaed6), [vtkFilter/FiberFilter.h](https://github.com/pnlbwh/ukftractography/compare/update-dependencies...dheshanm:ukftractography:fix-build-errors?expand=1#diff-0705497ebbc8f2012fa513807b58b472549e1ed6c5f49766c509b867bab35a1e)

After addressing these issues, the build runs to completion.